### PR TITLE
Define type aliases of `Error` and `ErrorPayload` for each backend client

### DIFF
--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -1,6 +1,11 @@
-use crate::client::tokio::{AsyncBackend, AsyncBackendResponse, AsyncClient};
-use crate::client::RequestParts;
-use crate::HttpUrl;
+use crate::{
+    client::{
+        tokio::{AsyncBackend, AsyncBackendResponse, AsyncClient},
+        RequestParts,
+    },
+    errors::{CommonError, Error, ErrorPayload},
+    HttpUrl,
+};
 use futures_util::TryStreamExt;
 use tokio_util::io::{ReaderStream, StreamReader};
 
@@ -49,3 +54,7 @@ impl AsyncBackendResponse for reqwest::Response {
         StreamReader::new(self.bytes_stream().map_err(std::io::Error::other))
     }
 }
+
+pub type ReqwestError<E = CommonError> = Error<reqwest::Error, E>;
+
+pub type ReqwestErrorPayload<E = CommonError> = ErrorPayload<reqwest::Error, E>;

--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -1,5 +1,8 @@
-use crate::client::{Backend, BackendResponse, Client, RequestParts};
-use crate::HttpUrl;
+use crate::{
+    client::{Backend, BackendResponse, Client, RequestParts},
+    errors::{CommonError, Error, ErrorPayload},
+    HttpUrl,
+};
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 
 pub type UreqClient = Client<ureq::Agent>;
@@ -67,3 +70,7 @@ impl BackendResponse for ureq::Response {
         self.into_reader()
     }
 }
+
+pub type UreqError<E = CommonError> = Error<ureq::Error, E>;
+
+pub type UreqErrorPayload<E = CommonError> = ErrorPayload<ureq::Error, E>;


### PR DESCRIPTION
Closes #17.