### PR TITLE
Add `reqwest`-based sync backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -988,6 +989,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ gh-token = { version = "0.1.7", optional = true }
 http = "1.2.0"
 mime = "0.3.17"
 parse_link_header = { version = "0.4.0", features = ["url"] }
-reqwest = { version = "0.12.12", optional = true, features = ["json", "stream"] }
+reqwest = { version = "0.12.12", optional = true, features = ["json"] }
 serde = "1.0.217"
 serde_json = "1.0.135"
 thiserror = "2.0.11"
@@ -34,7 +34,8 @@ rstest = { version = "0.24.0", default-features = false }
 [features]
 examples = ["dep:clap", "dep:gh-token", "serde/derive", "tokio?/macros", "tokio?/rt"]
 ureq = ["dep:ureq"]
-reqwest = ["dep:futures-util", "dep:reqwest", "tokio", "dep:tokio-util"]
+reqwest = ["dep:futures-util", "dep:reqwest", "reqwest/stream", "tokio", "dep:tokio-util"]
+reqwest-blocking = ["reqwest/blocking"]
 tokio = ["dep:tokio"]
 
 [[example]]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -263,7 +263,7 @@ pub trait Backend {
     // TODO: Should this be fallible?
     fn prepare_request(&self, r: RequestParts) -> Self::Request;
 
-    fn send<R: std::io::Read>(
+    fn send<R: std::io::Read + Send + 'static>(
         &self,
         r: Self::Request,
         body: R,

--- a/src/request.rs
+++ b/src/request.rs
@@ -42,7 +42,7 @@ pub trait RequestBody {
         HeaderMap::new()
     }
 
-    fn into_read(self) -> Result<impl std::io::Read + 'static, Self::Error>;
+    fn into_read(self) -> Result<impl std::io::Read + Send + 'static, Self::Error>;
 }
 
 #[cfg(feature = "tokio")]

--- a/src/reqwest/blocking.rs
+++ b/src/reqwest/blocking.rs
@@ -1,0 +1,48 @@
+use crate::{
+    client::{Backend, BackendResponse, Client, RequestParts},
+    HttpUrl,
+};
+
+pub type ReqwestBlockingClient = Client<reqwest::blocking::Client>;
+
+impl Backend for reqwest::blocking::Client {
+    type Request = reqwest::blocking::RequestBuilder;
+    type Response = reqwest::blocking::Response;
+    type Error = reqwest::Error;
+
+    fn prepare_request(&self, r: RequestParts) -> Self::Request {
+        let mut req = self
+            .request(r.method.into(), r.url.as_str())
+            .headers(r.headers);
+        if let Some(d) = r.timeout {
+            req = req.timeout(d);
+        }
+        req
+    }
+
+    fn send<R: std::io::Read + Send + 'static>(
+        &self,
+        r: Self::Request,
+        body: R,
+    ) -> Result<Self::Response, Self::Error> {
+        r.body(reqwest::blocking::Body::new(body)).send()
+    }
+}
+
+impl BackendResponse for reqwest::blocking::Response {
+    fn url(&self) -> HttpUrl {
+        HttpUrl::try_from(self.url().clone()).expect("response URL should be a valid HTTP URL")
+    }
+
+    fn status(&self) -> http::status::StatusCode {
+        self.status()
+    }
+
+    fn headers(&self) -> http::header::HeaderMap {
+        self.headers().clone()
+    }
+
+    fn body_reader(self) -> impl std::io::Read {
+        std::io::Cursor::new(self.bytes().unwrap())
+    }
+}

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "reqwest-blocking")]
+pub mod blocking;
+
 use crate::{
     client::{
         tokio::{AsyncBackend, AsyncBackendResponse, AsyncClient},

--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -25,7 +25,7 @@ impl Backend for ureq::Agent {
         req
     }
 
-    fn send<R: std::io::Read>(
+    fn send<R: std::io::Read + Send + 'static>(
         &self,
         r: Self::Request,
         body: R,


### PR DESCRIPTION
Closes #13.

Problems with this PR:

- Because [`reqwest::blocking::Body::new()`](https://docs.rs/reqwest/latest/reqwest/blocking/struct.Body.html#method.new) requires the reader to be `Sync`, `(Async)RequestBody::into_(async)_read()` will have to return a `Sync` reader.

- Because [`reqwest::blocking::Response::bytes()`](https://docs.rs/reqwest/latest/reqwest/blocking/struct.Response.html#method.bytes) is fallible, `(Async)BackendResponse::body_reader()` will have to become fallible.  (Not yet implemented)